### PR TITLE
feat: implement tractor requisition indexing

### DIFF
--- a/src/subgraphs/beanstalk/manifests/pinto.yaml
+++ b/src/subgraphs/beanstalk/manifests/pinto.yaml
@@ -485,12 +485,20 @@ dataSources:
       language: wasm/assemblyscript
       entities:
         - Tractor
+        - TractorRequisition
+        - TractorExecution
       abis:
         - name: PintoPI15
           file: ../../../core/abis/Beanstalk/Pinto-PI15.json
       eventHandlers:
         - event: Tractor(indexed address,indexed address,indexed bytes32,uint256,uint256)
           handler: handleTractor
+        - event: PublishRequisition(((address,bytes,bytes32[],uint256,uint256,uint256),bytes32,bytes))
+          handler: handlePublishRequisition
+        - event: CancelBlueprint(indexed bytes32)
+          handler: handleCancelBlueprint
+        - event: TractorExecutionBegan(indexed address,indexed address,indexed bytes32,uint256,uint256)
+          handler: handleTractorExecutionBegan
       file: ../src/handlers/TractorHandler.ts
   - kind: ethereum/contract
     name: TractorHelpersSowV0

--- a/src/subgraphs/beanstalk/schema.graphql
+++ b/src/subgraphs/beanstalk/schema.graphql
@@ -1915,6 +1915,94 @@ type TractorDailySnapshot @entity {
   updatedAt: BigInt!
 }
 
+type TractorRequisition @entity {
+  "blueprintHash (bytes32)"
+  id: Bytes!
+
+  "The publisher (farmer) who created this requisition"
+  publisher: Farmer!
+
+  "Raw blueprint data (encoded calldata)"
+  blueprintData: Bytes!
+
+  "Operator paste instructions"
+  operatorPasteInstrs: [Bytes!]!
+
+  "Maximum nonce (max number of times blueprint can execute)"
+  maxNonce: BigInt!
+
+  "Unix timestamp when blueprint becomes valid"
+  startTime: BigInt!
+
+  "Unix timestamp when blueprint expires"
+  endTime: BigInt!
+
+  "EIP-712 signature"
+  signature: Bytes!
+
+  "Whether this blueprint has been cancelled"
+  cancelled: Boolean!
+
+  "Number of times this blueprint has been executed"
+  executionCount: Int!
+
+  "Block number when published"
+  createdBlock: BigInt!
+
+  "Timestamp when published"
+  createdAt: BigInt!
+
+  "Transaction hash of publication"
+  createdHash: Bytes!
+
+  "Block number when cancelled (null if not cancelled)"
+  cancelledBlock: BigInt
+
+  "Timestamp when cancelled (null if not cancelled)"
+  cancelledAt: BigInt
+
+  "Transaction hash of cancellation (null if not cancelled)"
+  cancelledHash: Bytes
+
+  "Executions of this requisition"
+  executions: [TractorExecution!]! @derivedFrom(field: "requisition")
+}
+
+type TractorExecution @entity(immutable: true) {
+  "{txHash}-{logIndex}"
+  id: ID!
+
+  "The requisition this execution belongs to"
+  requisition: TractorRequisition!
+
+  "The operator who executed the blueprint"
+  operator: Bytes!
+
+  "The publisher whose blueprint was executed"
+  publisher: Farmer!
+
+  "Blueprint hash"
+  blueprintHash: Bytes!
+
+  "Nonce of this execution"
+  nonce: BigInt!
+
+  "Remaining gas at execution start"
+  gasleft: BigInt!
+
+  "Block number"
+  blockNumber: BigInt!
+
+  "Block timestamp"
+  timestamp: BigInt!
+
+  "Transaction hash"
+  transactionHash: Bytes!
+
+  "Log index within the transaction"
+  logIndex: BigInt!
+}
+
 ### LEGACY/BEANSTALK ###
 
 type UnripeToken @entity {

--- a/src/subgraphs/beanstalk/src/handlers/TractorHandler.ts
+++ b/src/subgraphs/beanstalk/src/handlers/TractorHandler.ts
@@ -1,9 +1,12 @@
+import { Address, Bytes } from "@graphprotocol/graph-ts";
 import { getProtocolToken } from "../../../../core/constants/RuntimeConstants";
 import { ZERO_BI } from "../../../../core/utils/Decimals";
-import { Tractor } from "../../generated/Beanstalk-ABIs/PintoPI15";
+import { Tractor, PublishRequisition, CancelBlueprint, TractorExecutionBegan } from "../../generated/Beanstalk-ABIs/PintoPI15";
 import { OperatorReward } from "../../generated/Beanstalk-ABIs/TractorHelpers";
 import { takeTractorSnapshots } from "../entities/snapshots/Tractor";
 import { loadTractor, loadTractorReward } from "../entities/Tractor";
+import { loadFarmer } from "../entities/Beanstalk";
+import { TractorRequisition, TractorExecution } from "../../generated/schema";
 import { v } from "../utils/constants/Version";
 
 export function handleTractor(event: Tractor): void {
@@ -41,4 +44,77 @@ export function handleOperatorReward(event: OperatorReward): void {
 
   takeTractorSnapshots(tractor, event.block);
   tractor.save();
+}
+
+export function handlePublishRequisition(event: PublishRequisition): void {
+  const blueprint = event.params.requisition.blueprint;
+  const blueprintHash = event.params.requisition.blueprintHash;
+
+  let requisition = TractorRequisition.load(blueprintHash);
+  if (requisition == null) {
+    requisition = new TractorRequisition(blueprintHash);
+    requisition.executionCount = 0;
+    requisition.cancelled = false;
+  }
+
+  const farmer = loadFarmer(blueprint.publisher, event.block);
+  requisition.publisher = farmer.id;
+  requisition.blueprintData = blueprint.data;
+
+  const rawInstrs = blueprint.operatorPasteInstrs;
+  const instrArray = new Array<Bytes>(rawInstrs.length);
+  for (let i = 0; i < rawInstrs.length; i++) {
+    instrArray[i] = rawInstrs[i];
+  }
+  requisition.operatorPasteInstrs = instrArray;
+
+  requisition.maxNonce = blueprint.maxNonce;
+  requisition.startTime = blueprint.startTime;
+  requisition.endTime = blueprint.endTime;
+  requisition.signature = event.params.requisition.signature;
+
+  requisition.createdBlock = event.block.number;
+  requisition.createdAt = event.block.timestamp;
+  requisition.createdHash = event.transaction.hash;
+
+  requisition.save();
+}
+
+export function handleCancelBlueprint(event: CancelBlueprint): void {
+  const blueprintHash = event.params.blueprintHash;
+  let requisition = TractorRequisition.load(blueprintHash);
+  if (requisition != null) {
+    requisition.cancelled = true;
+    requisition.cancelledBlock = event.block.number;
+    requisition.cancelledAt = event.block.timestamp;
+    requisition.cancelledHash = event.transaction.hash;
+    requisition.save();
+  }
+}
+
+export function handleTractorExecutionBegan(event: TractorExecutionBegan): void {
+  const id = event.transaction.hash.toHexString() + "-" + event.logIndex.toString();
+  const execution = new TractorExecution(id);
+
+  const blueprintHash = event.params.blueprintHash;
+  execution.requisition = blueprintHash;
+  execution.operator = event.params.operator;
+  execution.blueprintHash = blueprintHash;
+  execution.nonce = event.params.nonce;
+  execution.gasleft = event.params.gasleft;
+
+  const farmer = loadFarmer(event.params.publisher, event.block);
+  execution.publisher = farmer.id;
+
+  execution.blockNumber = event.block.number;
+  execution.timestamp = event.block.timestamp;
+  execution.transactionHash = event.transaction.hash;
+  execution.logIndex = event.logIndex;
+  execution.save();
+
+  let requisition = TractorRequisition.load(blueprintHash);
+  if (requisition != null) {
+    requisition.executionCount += 1;
+    requisition.save();
+  }
 }


### PR DESCRIPTION
This pull request adds support for tracking and indexing Tractor blueprint requisitions and executions in the Beanstalk subgraph. It introduces new entities and event handlers to capture the lifecycle of blueprint publication, cancellation, and execution, enabling more detailed analytics and querying of Tractor-related activity.

**Schema and Entity Additions:**

- Added two new entities, `TractorRequisition` and `TractorExecution`, to the GraphQL schema, capturing detailed information about blueprint requisitions, their publishers, execution state, and related events.

**Event Handling and Data Indexing:**

- Implemented new event handlers in `TractorHandler.ts` for:
  - [`PublishRequisition`](diffhunk://#diff-de602d35d4dc31603c490f7b4621bb9ced27f88924975f13a3ac0e9ab514b518R48-R120): Indexes new blueprint requisitions, storing metadata and publisher information.
  - [`CancelBlueprint`](diffhunk://#diff-de602d35d4dc31603c490f7b4621bb9ced27f88924975f13a3ac0e9ab514b518R48-R120): Updates the requisition entity to mark it as cancelled and records cancellation metadata.
  - [`TractorExecutionBegan`](diffhunk://#diff-de602d35d4dc31603c490f7b4621bb9ced27f88924975f13a3ac0e9ab514b518R48-R120): Indexes each execution of a blueprint, linking it to its requisition and updating execution counts.
- Registered these event handlers and their corresponding events in the subgraph manifest (`pinto.yaml`).

**Supporting Changes:**

- Updated imports and entity loading logic in `TractorHandler.ts` to support the new entities and event handlers.

These changes enable the subgraph to track the full lifecycle of Tractor blueprints, from publication through execution and cancellation, providing a foundation for advanced querying and analytics on Tractor activity.